### PR TITLE
Remove unsupported 'devel' method

### DIFF
--- a/Formula/wpe-cli.rb
+++ b/Formula/wpe-cli.rb
@@ -15,10 +15,6 @@ class WpeCli < Formula
     end
   end
   
-  devel do
-    url "https://s3-us-east-2.amazonaws.com/wpeclinightly/wpe-cli/nightly/wpe-cli_nightly_darwin_amd64.tar.gz"
-  end
-
   def install
     bin.install "wpe"
   end


### PR DESCRIPTION
It's impossible to install with current version of homebrew. This change makes it work again.